### PR TITLE
Adds the ability to hide elements from pa11y testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,20 +107,21 @@ Usage: pa11y [options] <url>
 
   Options:
 
-    -h, --help                 output usage information
-    -V, --version              output the version number
-    -s, --standard <name>      the accessibility standard to use: Section508, WCAG2A, WCAG2AA (default), WCAG2AAA
-    -r, --reporter <reporter>  the reporter to use: cli (default), csv, html, json
-    -l, --level <level>        the level of message to fail on (exit with code 2): error, warning, notice
-    -T, --threshold <name>     the number of individual errors, warnings, or notices to permit before failing
-    -i, --ignore <ignore>      types and codes of messages to ignore, a repeatable value or separated by semi-colons
-    -c, --config <path>        a JSON or JavaScript config file
-    -p, --port <port>          the port to run PhantomJS on
-    -t, --timeout <ms>         the timeout in milliseconds
-    -w, --wait <ms>            the time to wait before running tests in milliseconds
-    -d, --debug                output debug messages
-    -H, --htmlcs <url/path>    the URL or path to source HTML_CodeSniffer from
-    -e, --phantomjs <path>     the path to the phantomjs executable
+    -h, --help                  output usage information
+    -V, --version               output the version number
+    -s, --standard <name>       the accessibility standard to use: Section508, WCAG2A, WCAG2AA (default), WCAG2AAA
+    -r, --reporter <reporter>   the reporter to use: cli (default), csv, html, json
+    -l, --level <level>         the level of message to fail on (exit with code 2): error, warning, notice
+    -T, --threshold <name>      the number of individual errors, warnings, or notices to permit before failing
+    -i, --ignore <ignore>       types and codes of messages to ignore, a repeatable value or separated by semi-colons
+    -E, --hide-elements <hide>  a CSS selector to hide elements from testing, selectors can be comma separated
+    -c, --config <path>         a JSON or JavaScript config file
+    -p, --port <port>           the port to run PhantomJS on
+    -t, --timeout <ms>          the timeout in milliseconds
+    -w, --wait <ms>             the time to wait before running tests in milliseconds
+    -d, --debug                 output debug messages
+    -H, --htmlcs <url/path>     the URL or path to source HTML_CodeSniffer from
+    -e, --phantomjs <path>      the path to the phantomjs executable
 ```
 
 ### Running Tests
@@ -349,6 +350,17 @@ pa11y({
 ```
 
 Defaults to `null`.
+
+### `hideElements` (string)
+
+A CSS selector to hide elements from testing, selectors can be comma separated.
+Elements matching this selector will be hidden from testing by styling them with `visibility:hidden`.
+
+```js
+pa11y({
+	hideElements: '.advert, #modal, div[aria-role=presentation]'
+});
+```
 
 ### `htmlcs` (string)
 

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -39,6 +39,10 @@ function configureProgram(program) {
 			[]
 		)
 		.option(
+			'-E, --hide-elements <hide>',
+			'a CSS selector to hide elements from testing, selectors can be comma separated'
+		)
+		.option(
 			'-c, --config <path>',
 			'a JSON or JavaScript config file',
 			'./pa11y.json'
@@ -99,6 +103,7 @@ function runProgram(program) {
 
 function processOptions(program) {
 	var options = extend(true, {}, loadConfig(program.config), {
+		hideElements: program.hideElements,
 		htmlcs: program.htmlcs,
 		ignore: program.ignore,
 		log: loadReporter(program.reporter),
@@ -115,6 +120,7 @@ function processOptions(program) {
 		timeout: program.timeout,
 		wait: program.wait
 	});
+
 	if (!program.debug) {
 		options.log.debug = function() {};
 	}

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -8,8 +8,22 @@ function injectPa11y(window, options, done) {
 		2: 'warning',
 		3: 'notice'
 	};
-
+	if (options.hideElements) {
+		hideElements();
+	}
 	setTimeout(runCodeSniffer, options.wait);
+
+	function hideElements() {
+		try {
+			var elementsToHide = window.document.querySelectorAll(options.hideElements);
+			for (var i = 0; i < elementsToHide.length; i++) {
+				elementsToHide[i].style.visibility = 'hidden';
+			}
+
+		} catch (error) {
+			reportError('Hiding elements: ' + error.message);
+		}
+	}
 
 	function runCodeSniffer() {
 		try {

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -11,6 +11,7 @@ var trufflerPkg = require('truffler/package.json');
 module.exports = pa11y;
 module.exports.defaults = {
 	beforeScript: null,
+	hideElements: null,
 	htmlcs: __dirname + '/vendor/HTMLCS.js',
 	ignore: [],
 	log: {
@@ -130,6 +131,7 @@ function testPage(options, browser, page, done) {
 				}
 				injectPa11y(window, options, window.callPhantom);
 			}, {
+				hideElements: options.hideElements,
 				ignore: options.ignore,
 				standard: options.standard,
 				wait: options.wait

--- a/test/integration/cli-hide-elements.js
+++ b/test/integration/cli-hide-elements.js
@@ -1,0 +1,25 @@
+// jshint maxstatements: false
+// jscs:disable maximumLineLength
+'use strict';
+
+var assert = require('proclaim');
+var describeCliCall = require('./helper/describe-cli-call');
+
+describe('Pa11y CLI Hide Elements', function() {
+
+	describeCliCall('/hide-elements', ['--hide-elements', '.heading'], {}, function() {
+
+		it('should respond with an exit code of `0`', function() {
+			assert.strictEqual(this.lastExitCode, 0);
+		});
+
+		it('should respond with the expected messages', function() {
+			assert.isArray(this.lastJsonResponse);
+			assert.strictEqual(this.lastJsonResponse.length, 3);
+			assert.notStrictEqual(this.lastJsonResponse[0].type, 'error');
+			assert.notStrictEqual(this.lastJsonResponse[1].type, 'error');
+			assert.notStrictEqual(this.lastJsonResponse[2].type, 'error');
+		});
+
+	});
+});

--- a/test/integration/mock/html/hide-elements.html
+++ b/test/integration/mock/html/hide-elements.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+    <meta charset="utf-8"/>
+    <title>Hide Selectors</title>
+
+</head>
+<body style="background:#fff">
+	<h1 style="color:#fff" class="heading">Hello World</h1>
+</body>
+</html>

--- a/test/unit/lib/inject.js
+++ b/test/unit/lib/inject.js
@@ -29,6 +29,33 @@ describe('lib/inject', function() {
 		});
 	});
 
+	it('should select elements using `hideElements` option', function(done) {
+		options.hideElements = '#ad, .modal';
+		inject(window, options, function() {
+			assert.calledOnce(window.document.querySelectorAll);
+			assert.calledWith(window.document.querySelectorAll, '#ad, .modal');
+			done();
+		});
+	});
+
+	it('should hide the elements set in the `hideElements` option', function(done) {
+		options.hideElements = '#ad, .modal';
+		var mockElement1 = {
+			style: {}
+		};
+		var mockElement2 = {
+			style: {}
+		};
+
+		window.document.querySelectorAll.returns([mockElement1, mockElement2]);
+
+		inject(window, options, function() {
+			assert.strictEqual(mockElement1.style.visibility, 'hidden');
+			assert.strictEqual(mockElement2.style.visibility, 'hidden');
+			done();
+		});
+	});
+
 	it('should wait before processing the page if `options.wait` is set', function(done) {
 		// Note: this test isn't particularly reliable, revisit some time
 		var start = Date.now();

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -337,6 +337,7 @@ describe('lib/pa11y', function() {
 			assert.calledOnce(phantom.mockPage.evaluate);
 			assert.isFunction(phantom.mockPage.evaluate.firstCall.args[0]);
 			assert.deepEqual(phantom.mockPage.evaluate.firstCall.args[1], {
+				hideElements: null,
 				ignore: [
 					'baz',
 					'qux'

--- a/test/unit/mock/window.js
+++ b/test/unit/mock/window.js
@@ -4,7 +4,9 @@ var sinon = require('sinon');
 
 module.exports = {
 	callPhantom: sinon.spy(),
-	document: {},
+	document: {
+		querySelectorAll: sinon.stub().returns([])
+	},
 	HTMLCS: {
 		getMessages: sinon.stub().returns([]),
 		process: sinon.stub().yieldsAsync()


### PR DESCRIPTION
This will allow areas of the page to be hidden before running HTML code
sniffer against the page. This relies on the fact that HTML code sniffer
will ignore anything thats `visibility` style is set to `hidden`.

The option accepts a string which allows for coma seperated selectors in
the same way as `querySelectorAll`.

e.g. "#modal, .adverts, div[data-hide]"